### PR TITLE
Make profile endpoint optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ hesitate to mail us.
 * `<path>/oauth2callback` -- OAuth callback
 * `<path>/logout` -- start logout roundtrip 
 * `<path>/logoutcallback` -- start logout roundtrip 
-* `<path>/profile` -- Info callback
+
+You can add a session endpoint that shows the logged in user's properties by
+adding this to your code:
+
+    http.HandleFunc("/connect/profile", connect.SessionProfile)
 
 ## Demo client setup
     Client ID:   telenordigital-connectexample-web

--- a/connect.go
+++ b/connect.go
@@ -206,8 +206,15 @@ func (t *GoConnect) isAuthorized(w http.ResponseWriter, r *http.Request) (bool, 
 	return true, session
 }
 
-// Show session info (if there is one)
-func (t *GoConnect) showSessionInfo(w http.ResponseWriter, r *http.Request) {
+// SessionProfile is a premade session endpoint that you can use to serve the
+// profile information to the end user. Since this resource might be used
+// by JavaScript clients it would potentially need CORS headers and a matching
+// OPTIONS header but this might introduce security issues. Add the header
+// to the default mux by using the following snippet:
+//
+//     http.HandleFunc("/connect/profile", connect.SessionProfile)
+//
+func (t *GoConnect) SessionProfile(w http.ResponseWriter, r *http.Request) {
 	auth, session := t.isAuthorized(w, r)
 	if !auth {
 		return
@@ -282,10 +289,6 @@ func (c *connectHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	if strings.HasSuffix(r.URL.Path, c.connect.Config.LoginCallback) {
 		c.connect.loginComplete(w, r)
-		return
-	}
-	if strings.HasSuffix(r.URL.Path, c.connect.Config.ProfileEndpoint) {
-		c.connect.showSessionInfo(w, r)
 		return
 	}
 	if strings.HasSuffix(r.URL.Path, c.connect.Config.LogoutInit) {


### PR DESCRIPTION
If you use JavaScript to access the profile endpoint (which is likely
you'll need CORS-enabled resources with the appropriate headers and
an response for the OPTIONS method. Rather than assuming everyone
wants to open up their API to the world the profile endpoint is
optional.