### PR TITLE
The Session type is plain old data; it should not be passed around as…

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -213,16 +213,16 @@ func (t *GoConnect) loginComplete(w http.ResponseWriter, r *http.Request) {
 }
 
 // Check if there is a session. Set error and return otherwise
-func (t *GoConnect) isAuthorized(w http.ResponseWriter, r *http.Request) (bool, *Session) {
+func (t *GoConnect) isAuthorized(w http.ResponseWriter, r *http.Request) (bool, Session) {
 	cookie, err := r.Cookie(connectIDCookieName)
 	if cookie == nil || err == http.ErrNoCookie {
 		http.Error(w, "You are not authorized to view this page. Try logging in again.", http.StatusUnauthorized)
-		return false, nil
+		return false, Session{}
 	}
 	session, err := t.storage.GetSession(cookie.Value)
 	if err == errorNoSession {
 		http.Error(w, "You are not authorized to view this page. Try logging in again.", http.StatusUnauthorized)
-		return false, nil
+		return false, Session{}
 	}
 
 	return true, session

--- a/storage.go
+++ b/storage.go
@@ -69,10 +69,10 @@ type Storage interface {
 
 	// PutSession creates a new session identifier and stores
 	// the information in a session structure
-	PutSession(session *Session) error
+	PutSession(session Session) error
 
 	// GetSession returns the session associated with the session ID.
-	GetSession(sessionid string) (*Session, error)
+	GetSession(sessionid string) (Session, error)
 
 	// DeleteSession removes the session
 	DeleteSession(sessionid string)
@@ -86,7 +86,7 @@ type Storage interface {
 type memoryStorage struct {
 	mutex    *sync.Mutex
 	nonces   map[string]time.Time
-	sessions map[string]*Session
+	sessions map[string]Session
 }
 
 // NewMemoryStorage creates a new memory-backed storage implementation. This implementation
@@ -98,7 +98,7 @@ func NewMemoryStorage() Storage {
 	storage := &memoryStorage{
 		mutex:    &sync.Mutex{},
 		nonces:   make(map[string]time.Time),
-		sessions: make(map[string]*Session),
+		sessions: make(map[string]Session),
 	}
 	go storage.sessionChecker()
 	return storage
@@ -165,11 +165,11 @@ type Session struct {
 }
 
 // newSession creates a new session
-func newSession(jwt jwt, accessToken string, refreshToken string, expires int) *Session {
+func newSession(jwt jwt, accessToken string, refreshToken string, expires int) Session {
 	randomBytes := make([]byte, 64)
 	rand.Read(randomBytes)
 	newSessionID := hex.EncodeToString(randomBytes)
-	return &Session{
+	return Session{
 		id:            newSessionID,
 		UserID:        jwt.Claims.ID,
 		Name:          jwt.Claims.Name,
@@ -183,22 +183,22 @@ func newSession(jwt jwt, accessToken string, refreshToken string, expires int) *
 		expires:       time.Now().Add(time.Duration(expires) * time.Second).Unix(),
 	}
 }
-func (m *memoryStorage) PutSession(session *Session) error {
+func (m *memoryStorage) PutSession(session Session) error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.sessions[session.id] = session
 	return nil
 }
 
-func (m *memoryStorage) GetSession(sessionID string) (*Session, error) {
+func (m *memoryStorage) GetSession(sessionID string) (Session, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	sess, exists := m.sessions[sessionID]
 	if !exists {
-		return nil, errorNoSession
+		return Session{}, errorNoSession
 	}
 	if sess.expires < time.Now().Unix() {
-		return nil, errorNoSession
+		return Session{}, errorNoSession
 	}
 	return sess, nil
 }
@@ -233,7 +233,7 @@ func (m *memoryStorage) sessionChecker() {
 }
 
 // Refresh the access token for a session.
-func (m *memoryStorage) refreshAccessToken(config ClientConfig, session *Session) {
+func (m *memoryStorage) refreshAccessToken(config ClientConfig, session Session) {
 	params := url.Values{}
 	params.Set("grant_type", "refresh_token")
 	params.Set("refresh_token", session.refreshToken)
@@ -283,7 +283,7 @@ func (m *memoryStorage) refreshAccessToken(config ClientConfig, session *Session
 		Phone:         session.Phone,
 		VerifiedPhone: session.VerifiedPhone,
 	}
-	m.sessions[updatedSession.id] = &updatedSession
+	m.sessions[updatedSession.id] = updatedSession
 }
 
 func (m *memoryStorage) RefreshTokens(config ClientConfig, lookAhead time.Duration) {


### PR DESCRIPTION
… a pointer (which would imply that it might mutate).

This will break existing clients – and _not_ at compile time, because context values require type assertions.  But no one is dumb enough to depend on master, right?  😉 